### PR TITLE
Add support for escaped double quotes in quoted strings and slashes in comments

### DIFF
--- a/openstep_parser/openstep_parser.py
+++ b/openstep_parser/openstep_parser.py
@@ -165,7 +165,7 @@ class OpenStepDecoder:
         # move after the first character in the comment
         index += 2
 
-        while str[index] != '*' and str[index + 1] != '/':
+        while not (str[index] == '*' and str[index + 1] == '/'):
             index += 1
 
         # move after the first character after the comment

--- a/openstep_parser/openstep_parser.py
+++ b/openstep_parser/openstep_parser.py
@@ -129,7 +129,12 @@ class OpenStepDecoder:
         if str[index] == '"':
             index += 1
             # if the literal starts with " then spaces are allowed
-            while index < len(str) and str[index] != '"':
+            escaped = False
+            while index < len(str) and (escaped or str[index] != '"'):
+                if not escaped and str[index] == '\\':
+                    escaped = True
+                else:
+                    escaped = False
                 key += str[index]
                 index += 1
             index += 1
@@ -140,8 +145,6 @@ class OpenStepDecoder:
                 index += 1
 
         index = self._parse_padding(str, index)
-        key = re.sub(r'^"', '', key)
-        key = re.sub(r'"$', '', key)
         return key, index
 
     def _parse_value(self, str, index):

--- a/openstep_parser/openstep_parser.py
+++ b/openstep_parser/openstep_parser.py
@@ -131,11 +131,15 @@ class OpenStepDecoder:
             # if the literal starts with " then spaces are allowed
             escaped = False
             while index < len(str) and (escaped or str[index] != '"'):
-                if not escaped and str[index] == '\\':
+                d = {'"': '"', "'": "'", "0": "\0", "\\": "\\", "n":"\n"}
+                if escaped:
+                    key += d[str[index]]
+                    escaped = False
+                elif not escaped and str[index] == '\\':
                     escaped = True
                 else:
+                    key += str[index]
                     escaped = False
-                key += str[index]
                 index += 1
             index += 1
         else:

--- a/tests/parsing.py
+++ b/tests/parsing.py
@@ -70,8 +70,8 @@ class Parsing(unittest.TestCase):
 
     def testIgnoreComment(self):
         parser = osp.OpenStepDecoder()
-        index = parser._ignore_comment('/*1234567890*/ ', 0)
-        assert index == 14
+        index = parser._ignore_comment('/*12345/67890*/ ', 0)
+        assert index == 15
 
     def testIgnoreFakeComment(self):
         parser = osp.OpenStepDecoder()

--- a/tests/parsing.py
+++ b/tests/parsing.py
@@ -87,9 +87,9 @@ class Parsing(unittest.TestCase):
 
     def testParsingKeyQuoted(self):
         parser = osp.OpenStepDecoder()
-        line = '    /* some comments */ "KEY-NAME" '
+        line = '    /* some comments */ "KEY-\\"NAME\\"" '
         key, index = parser._parse_key(line, 0)
-        assert key == 'KEY-NAME'
+        assert key == 'KEY-\\"NAME\\"'
         assert index == len(line)
 
     def testDictionaryEntry(self):

--- a/tests/parsing.py
+++ b/tests/parsing.py
@@ -87,9 +87,9 @@ class Parsing(unittest.TestCase):
 
     def testParsingKeyQuoted(self):
         parser = osp.OpenStepDecoder()
-        line = '    /* some comments */ "KEY-\\"NAME\\"" '
+        line = '    /* some comments */ "KEY-NAME" '
         key, index = parser._parse_key(line, 0)
-        assert key == 'KEY-\\"NAME\\"'
+        assert key == 'KEY-NAME'
         assert index == len(line)
 
     def testDictionaryEntry(self):
@@ -99,6 +99,14 @@ class Parsing(unittest.TestCase):
         index = parser._parse_dictionary_entry(line, 0, result)
 
         assert result['KEY-NAME'] == 'value-1234'
+
+    def testDictionaryEntryQuoted(self):
+        parser = osp.OpenStepDecoder()
+        line = '    /* some comments */ KEY-NAME   /* asd */ =   /* adfasdf */  "value\\n\\"1234\\""    /* adfasdf */   ;'
+        result = {}
+        index = parser._parse_dictionary_entry(line, 0, result)
+
+        assert result['KEY-NAME'] == 'value\n"1234"'
 
     def testDictionaryEntryMissingEqual(self):
         parser = osp.OpenStepDecoder()


### PR DESCRIPTION
Necessary to parse an Xcode project I have using [kronenthaler/mod-pbxproj](https://github.com/kronenthaler/mod-pbxproj) and `pure_python` option.