### PR TITLE
Fixing parsing error when dictionary or arrays do not add a final ';' or ',' before the last term

### DIFF
--- a/openstep_parser/openstep_parser.py
+++ b/openstep_parser/openstep_parser.py
@@ -97,20 +97,31 @@ class OpenStepDecoder(object):
         index = self._parse_padding(str, index + 1)
         value, index = self._parse_value(str, index)
 
+        dictionary[key] = value
+
+        if str[index] == '}':
+            # Let the caller know we're finished by NOT skipping the "}" from the stream.
+            return index
+
         if str[index] != ';':
             raise Exception("Expected ; after a value. Found {1} @ {0}".format(index, str[index]))
 
-        dictionary[key] = value
+        # Skip the ";" character.
         return index + 1
 
     def _parse_array_entry(self, str, index, array):
         # parse a: dict, array or value until the ','
         value, index = self._parse_value(str, index)
 
+        array.append(value)
+
+        if str[index] == ')':
+            # Let the caller know we're finished by NOT skipping the "]" from the stream.
+            return index
+
         if str[index] != ',':
             raise Exception("Expected , after a value. Found {1} @ {0} = {2}".format(index, str[index], value))
 
-        array.append(value)
         return index + 1
 
     def _parse_padding(self, str, index):
@@ -156,7 +167,7 @@ class OpenStepDecoder(object):
             index += 1
         else:
             # otherwise stop in the spaces.
-            while index < len(str) and not self._is_whitespace(str[index]) and str[index] != ';' and str[index] != ',':
+            while index < len(str) and not self._is_whitespace(str[index]) and str[index] not in (';', ',', '}', ')'):
                 key += str[index]
                 index += 1
 

--- a/openstep_parser/openstep_parser.py
+++ b/openstep_parser/openstep_parser.py
@@ -116,7 +116,7 @@ class OpenStepDecoder(object):
         array.append(value)
 
         if str[index] == ')':
-            # Let the caller know we're finished by NOT skipping the "]" from the stream.
+            # Let the caller know we're finished by NOT skipping the ")" from the stream.
             return index
 
         if str[index] != ',':

--- a/tests/parsing.py
+++ b/tests/parsing.py
@@ -143,6 +143,30 @@ class Parsing(unittest.TestCase):
         except Exception:
             pass
 
+    def testFullDictionary(self):
+        parser = osp.OpenStepDecoder()
+        line = '{ ' \
+               '    /* some comments */ KEY-NAME1   /* asd */  =  /* adfasdf */  value-1234    /* adfasdf */ ;  ' \
+               '    /* some comments */ KEY-NAME2   /* asd */  =  /* adfasdf */  value-5678    /* adfasdf */ ;  ' \
+               '}'
+        result, index = parser._parse_dictionary(line, 0)
+        assert len(result) == 2
+        assert result['KEY-NAME1'] == 'value-1234'
+        assert result['KEY-NAME2'] == 'value-5678'
+
+    def testFullDictionaryWithoutEndingSemicolon(self):
+        # Note that there's no semicolon between value-5678 and "}".
+        parser = osp.OpenStepDecoder()
+        line = '{ ' \
+               '    /* some comments */ KEY-NAME1   /* asd */  =  /* adfasdf */  value-1234    /* adfasdf */ ;  ' \
+               '    /* some comments */ KEY-NAME2   /* asd */  =  /* adfasdf */  value-5678' \
+               '}'
+        result, index = parser._parse_dictionary(line, 0)
+        assert len(result) == 2
+        assert result['KEY-NAME1'] == 'value-1234'
+        assert result['KEY-NAME2'] == 'value-5678'
+
+
     def testArrayEntry(self):
         parser = osp.OpenStepDecoder()
         line = '    /* some comments */ KEY-NAME   /* asd */  , '
@@ -159,6 +183,21 @@ class Parsing(unittest.TestCase):
                '    GHI,' \
                ')'
         result, index = parser._parse_array(line, 0)
+        assert len(result) == 3
+        assert result[0] == 'ABC'
+        assert result[1] == 'DEF'
+        assert result[2] == 'GHI'
+
+    def testFullArrayWithoutEndingComma(self):
+        # Note that there's no comma between GHI and ")".
+        parser = osp.OpenStepDecoder()
+        line = '( ' \
+               '    ABC,' \
+               '    DEF,' \
+               '    GHI'  \
+               ')'
+        result, index = parser._parse_array(line, 0)
+        assert len(result) == 3
         assert result[0] == 'ABC'
         assert result[1] == 'DEF'
         assert result[2] == 'GHI'


### PR DESCRIPTION
When a project is generated by CMAKE it creates arrays without a separator between the last term of the array/dictionary and the ")" or "}"  end characters.

For example, this is the dictionary that CMAKE generates for `FRAMEWORK_SEARCH_PATHS`. Notice how there's no "," between `myfolder` and `)`.
```
FRAMEWORK_SEARCH_PATHS = (/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/Frameworks,/Users/achicu/code/myfolder);
```
