### PR TITLE
Speed up parsing

### DIFF
--- a/tests/parsing.py
+++ b/tests/parsing.py
@@ -58,31 +58,22 @@ class Parsing(unittest.TestCase):
 
     def testIgnoreWhitespacesFromBeginning(self):
         parser = osp.OpenStepDecoder()
-        index = parser._ignore_whitespaces('   3 ', 0)
+        index = parser._parse_padding('   3 ', 0)
         assert index == 3
 
     def testIgnoreWhitespacesInTheMiddle(self):
         parser = osp.OpenStepDecoder()
-        index = parser._ignore_whitespaces('0   3 ', 1)
+        index = parser._parse_padding('0   3 ', 1)
         assert index == 4
-
-    def testIsWhitespace(self):
-        parser = osp.OpenStepDecoder()
-        assert not parser._is_whitespace('a')
-        assert not parser._is_whitespace('0')
-        assert parser._is_whitespace('\t')
-        assert parser._is_whitespace('\r')
-        assert parser._is_whitespace('\n')
-        assert parser._is_whitespace(' ')
 
     def testIgnoreComment(self):
         parser = osp.OpenStepDecoder()
-        index = parser._ignore_comment('/*12345/67890*/ ', 0)
-        assert index == 15
+        index = parser._parse_padding('/*12345/67890*/ a', 0)
+        assert index == 16
 
     def testIgnoreFakeComment(self):
         parser = osp.OpenStepDecoder()
-        index = parser._ignore_comment('/bin/sh/ ', 0)
+        index = parser._parse_padding('/bin/sh/ ', 0)
         assert index == 0
 
     def testParsingKey(self):


### PR DESCRIPTION
This makes a few improvements to make parsing of large projects fairly significantly faster. On my machine, on an example project (which is about 10 MB) it goes from taking 5.9 seconds to parse (fastest of 10 runs) to taking 1.8 seconds, a 3x speedup. Note that I calculated minimum for how fast we could reasonably parse a project of this size by looping over each character, checking if it is "a" and incrementing a counter. This baseline minimum took 0.9 seconds, so we're much closer to that now.

The basic strategies taken here were to speed up padding/whitespace/comment parsing by using a `frozenset` to check whether a character was one of the ones we care about (which is significantly faster than chaining `or`'d equalities), inlining methods (particularly those that are only used once or a called the most, such as `_ignore_whitespace` and `_ignore_comment`), and pulling string values from the input string as one, rather than building them one character at a time.