### PR TITLE
fix parsing dictionaries with no whitespace around `=`

### DIFF
--- a/openstep_parser/openstep_parser.py
+++ b/openstep_parser/openstep_parser.py
@@ -28,7 +28,7 @@ import sys
 
 _WHITESPACE = frozenset(' \t\n\r')
 _UNQUOTED_LITERAL_ENDER = frozenset(';,})').union(_WHITESPACE)
-_KEY_ENDER = frozenset(';').union(_WHITESPACE)
+_KEY_ENDER = frozenset(';=').union(_WHITESPACE)
 _LITERAL_ESCAPES = {'\\"': '"', "\\'": "'", "\\0": "\0", "\\\\": "\\", "\\n": "\n", "\\t": "\t"}
 
 
@@ -152,14 +152,18 @@ class OpenStepDecoder(object):
         index = self._parse_padding(str, index)
 
         start_index = index
-        while str[index] not in _KEY_ENDER:
+        if str[index] == '"':
             index += 1
-
-        end_index = index
-        if str[start_index] == '"':
+            while str[index] != '"':
+                index += 1
             start_index += 1
-        if str[end_index-1] == '"':
-            end_index -= 1
+            end_index = index
+            index += 1
+        else:
+            while str[index] not in _KEY_ENDER:
+                index += 1
+            end_index = index
+
         key = str[start_index:end_index]
 
         index = self._parse_padding(str, index)

--- a/tests/TestParsing.py
+++ b/tests/TestParsing.py
@@ -50,6 +50,10 @@ class Parsing(unittest.TestCase):
         result = osp.OpenStepDecoder.ParseFromFile(open('tests/samples/metal-image-processing.pbxproj'))
         assert result
 
+    def testParseFileSample5(self):
+        result = osp.OpenStepDecoder.ParseFromFile(open('tests/samples/no_whitespace.pbxproj'))
+        assert result
+
     def testIgnoreWhitespacesFromBeginning(self):
         parser = osp.OpenStepDecoder()
         index = parser._parse_padding('   3 ', 0)

--- a/tests/samples/no_whitespace.pbxproj
+++ b/tests/samples/no_whitespace.pbxproj
@@ -1,0 +1,2 @@
+// !$*UTF8*$!
+{archiveVersion=1;classes={};objectVersion=45;objects={};}


### PR DESCRIPTION
I've run into a pbxproj's that pbxproj.XcodeProject has trouble loading.

The traceback:

```txt
  File "/Users/bojan/Projects/TabTale/github/CL_App_Builder/test_pbxproj.py", line 12, in main
    proj = XcodeProject.load(pbx)
  File "/Users/bojan/Projects/TabTale/github/CL_App_Builder/.venv/lib/python3.8/site-packages/pbxproj/XcodeProject.py", line 92, in load
    tree = osp.OpenStepDecoder.ParseFromFile(file)
  File "/Users/bojan/Projects/TabTale/github/CL_App_Builder/.venv/lib/python3.8/site-packages/openstep_parser/openstep_parser.py", line 40, in ParseFromFile
    return cls.ParseFromString(fp.read())
  File "/Users/bojan/Projects/TabTale/github/CL_App_Builder/.venv/lib/python3.8/site-packages/openstep_parser/openstep_parser.py", line 46, in ParseFromString
    return OpenStepDecoder()._parse(str)
  File "/Users/bojan/Projects/TabTale/github/CL_App_Builder/.venv/lib/python3.8/site-packages/openstep_parser/openstep_parser.py", line 55, in _parse
    result, index = self._parse_dictionary(str, index)
  File "/Users/bojan/Projects/TabTale/github/CL_App_Builder/.venv/lib/python3.8/site-packages/openstep_parser/openstep_parser.py", line 67, in _parse_dictionary
    index = self._parse_dictionary_entry(str, index, obj)
  File "/Users/bojan/Projects/TabTale/github/CL_App_Builder/.venv/lib/python3.8/site-packages/openstep_parser/openstep_parser.py", line 94, in _parse_dictionary_entry
    raise Exception("Expected = after a key. Found {1} @ {0}".format(index, str[index]))
Exception: Expected = after a key. Found ; @ 31
```
I can't share the actual pbxproj files, but `plutil -lint` says they are ok.

Here's a fix along with a syntetic test for this case.